### PR TITLE
Upgrade to API 28

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion versions.compileSdkVersion
-    buildToolsVersion versions.buildToolsVersion
 
     defaultConfig {
         applicationId "com.hextremelabs.pinpad.demo"
@@ -23,16 +22,15 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile project(":library")
-    compile libraries.supportAnnotations
-    compile libraries.supportAppcompat
-    compile libraries.kotlinStdLib
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(":library")
+    implementation libraries.supportAnnotations
+    implementation libraries.supportAppcompat
+    implementation libraries.kotlinStdLib
 
 
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    compile 'com.android.support.constraint:constraint-layout:1.0.2'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 }

--- a/app/src/main/java/com/hextremelabs/pinpad/demo/MainActivity.kt
+++ b/app/src/main/java/com/hextremelabs/pinpad/demo/MainActivity.kt
@@ -8,8 +8,8 @@ import com.hextremelabs.pinpad.PinpadView
 
 class MainActivity : AppCompatActivity(), PinpadView.Callback {
 
-    internal val pinpad by lazy { findViewById(R.id.pinpad) as PinpadView }
-    internal val pinview by lazy { findViewById(R.id.pinview) as PinTextView }
+    private val pinpad by lazy { findViewById<PinpadView>(R.id.pinpad) }
+    private val pinview by lazy { findViewById<PinTextView>(R.id.pinview) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
             targetSdkVersion : 28,
             compileSdkVersion: 28,
             versionCode      : 1,
-            versionName      : '0.1.0',
+            versionName      : '0.1.1',
             kotlinVersion    : '1.3.40'
     ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,13 @@
 buildscript {
 
     ext.versions = [
-            buildToolsVersion: '25.0.2',
-            supportLibVersion: '25.3.0',
+            supportLibVersion: '28.0.0',
             minSdkVersion    : 15,
-            targetSdkVersion : 25,
-            compileSdkVersion: 25,
+            targetSdkVersion : 28,
+            compileSdkVersion: 28,
             versionCode      : 1,
             versionName      : '0.1.0',
-            kotlinVersion    : '1.1.1'
+            kotlinVersion    : '1.3.40'
     ]
 
     ext.libraries = [
@@ -19,17 +18,17 @@ buildscript {
             supportAnnotations: "com.android.support:support-annotations:${versions.supportLibVersion}",
             supportAppcompat  : "com.android.support:appcompat-v7:${versions.supportLibVersion}",
             supportDesign     : "com.android.support:design:${versions.supportLibVersion}",
-            kotlinStdLib      : "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlinVersion}",
-            calligraphy       : "uk.co.chrisjenx:calligraphy:2.1.0"
+            kotlinStdLib      : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlinVersion}"
     ]
 
     repositories {
+        google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlinVersion}"
 
         // NOTE: Do not place your application dependencies here; they belong
@@ -39,6 +38,7 @@ buildscript {
 
 allprojects {
     repositories {
+        google()
         jcenter()
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,7 +3,6 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion versions.compileSdkVersion
-    buildToolsVersion versions.buildToolsVersion
 
     defaultConfig {
         minSdkVersion versions.minSdkVersion
@@ -23,14 +22,13 @@ android {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile libraries.supportAppcompat
-    compile libraries.kotlinStdLib
-    compile libraries.calligraphy
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation libraries.supportAppcompat
+    implementation libraries.kotlinStdLib
 
-    testCompile 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.12'
 
-    androidTestCompile('com.android.support.test.espresso:espresso-core:2.2.2', {
+    androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 }


### PR DESCRIPTION
**Description**
Upgrade library to API 28
- upgrades Kotlin to 1.3.40
- upgrades Gradle to 5.4.1
- upgrades AGP to 3.4.1
- removes Calligraphy dependency
- fixes crash on pre-L devices

**Note**
This doesn't migrate the library to AndroidX yet. That will be a much bigger bump than patch